### PR TITLE
Generic game score

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! # impl ai_tournament::game_interface::Game for YourGame {
 //! #     type State = u32;
 //! #     type Action = u32;
+//! #     type Score = f32;
 //! #     fn apply_action(&mut self, _action: &Option<Self::Action>) -> anyhow::Result<()> { Ok(()) }
 //! #     fn get_state(&self) -> Self::State { 0 }
 //! #     fn get_current_player_number(&self) -> usize { 0 }
@@ -68,7 +69,7 @@
 //!     let evaluator = Evaluator::new(factory, config, constraints);
 //!
 //!     let mut tournament = SinglePlayerTournament::new(10); // Run 10 games per agent
-//!     let results: HashMap<String, SinglePlayerScore> =
+//!     let results: HashMap<String, SinglePlayerScore<_>> =
 //!         evaluator.evaluate("path_to_agents_directory", tournament)?;
 //!
 //!     // Sort and display scores
@@ -96,6 +97,7 @@
 //! # impl ai_tournament::game_interface::Game for YourGame {
 //! #     type State = u32;
 //! #     type Action = u32;
+//! #     type Score = f32;
 //! #     fn apply_action(&mut self, _action: &Option<Self::Action>) -> anyhow::Result<()> { Ok(()) }
 //! #     fn get_state(&self) -> Self::State { 0 }
 //! #     fn get_current_player_number(&self) -> usize { 0 }

--- a/src/match_runner.rs
+++ b/src/match_runner.rs
@@ -26,11 +26,14 @@ impl Display for MatchSettings {
     }
 }
 
-pub type MatchResult = Vec<(Arc<Agent>, f32)>;
+pub type MatchResult<S> = Vec<(Arc<Agent>, S)>;
 
 #[derive(Debug, Clone)]
-pub struct RunnerResult {
-    pub results: MatchResult,
+pub struct RunnerResult<S>
+where
+    S: PartialOrd,
+{
+    pub results: MatchResult<S>,
     pub resources_freed: Constraints,
     pub errors: String,
     // pub duration: Duration,
@@ -41,11 +44,7 @@ pub fn run_match<G: Game>(
     settings: MatchSettings,
     config: Configuration,
     mut game: G,
-) -> RunnerResult
-where
-    G::Action: FromStr + ToString,
-    G::State: ToString,
-{
+) -> RunnerResult<G::Score> {
     trace!("game started");
     let MatchSettings {
         ordered_player,
@@ -210,8 +209,8 @@ where
     let mut results = vec![];
     for (i, agent) in ordered_player.iter().enumerate() {
         let score = game.get_player_score(i as u32);
-        results.push((agent.clone(), score));
         result_str.push(score.to_string());
+        results.push((agent.clone(), score));
     }
 
     let result_str = result_str.join("-");

--- a/src/tournament_scheduler.rs
+++ b/src/tournament_scheduler.rs
@@ -8,21 +8,24 @@ use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 
-pub struct TournamentScheduler<S: TournamentStrategy> {
+pub struct TournamentScheduler<T: TournamentStrategy<S>, S>
+where
+    S: PartialOrd,
+{
     // pub agents: Vec<Arc<Agent>>,
-    scores: Vec<MatchResult>,
+    scores: Vec<MatchResult<S>>,
     resources: Constraints,
     pending_matches: Vec<Vec<Arc<Agent>>>,
-    strategy: S,
+    strategy: T,
     running_matches: usize,
     is_finished: bool,
 }
 
-impl<S: TournamentStrategy> TournamentScheduler<S> {
+impl<T: TournamentStrategy<S>, S: PartialOrd> TournamentScheduler<T, S> {
     pub fn new(
         // agents: Vec<Arc<Agent>>,
         resources: Constraints,
-        strategy: S,
+        strategy: T,
     ) -> Self {
         TournamentScheduler {
             // agents,
@@ -69,7 +72,7 @@ impl<S: TournamentStrategy> TournamentScheduler<S> {
         matches_to_run
     }
 
-    pub fn on_result(&mut self, result: RunnerResult) -> Vec<MatchSettings> {
+    pub fn on_result(&mut self, result: RunnerResult<S>) -> Vec<MatchSettings> {
         self.scores.push(result.results);
         self.resources.add(result.resources_freed);
         self.running_matches -= 1;
@@ -81,7 +84,7 @@ impl<S: TournamentStrategy> TournamentScheduler<S> {
         self.is_finished // self.strategy.is_complete() && self.pending_matches.is_empty() && self.running_matches == 0
     }
 
-    pub fn final_scores(&self) -> HashMap<Arc<Agent>, S::FinalScore> {
+    pub fn final_scores(&self) -> HashMap<Arc<Agent>, T::FinalScore> {
         self.strategy.get_final_scores()
     }
 }

--- a/tests/games.rs
+++ b/tests/games.rs
@@ -15,6 +15,8 @@ impl Game for DummyGame {
 
     type Action = u32;
 
+    type Score = u32;
+
     fn apply_action(&mut self, _action: &Option<Self::Action>) -> anyhow::Result<()> {
         self.got_none |= _action.is_none();
         Ok(())
@@ -29,11 +31,11 @@ impl Game for DummyGame {
         *self.counter.borrow() <= 0
     }
 
-    fn get_player_score(&self, _player_number: u32) -> f32 {
+    fn get_player_score(&self, _player_number: u32) -> u32 {
         if self.got_none {
-            0.0
+            0
         } else {
-            1.0
+            1
         }
     }
 
@@ -285,6 +287,8 @@ impl Game for RPSWrapper {
     type State = PlayerState;
 
     type Action = RpsAction;
+
+    type Score = f32;
 
     fn apply_action(&mut self, action: &Option<Self::Action>) -> anyhow::Result<()> {
         self.actions_buffer.push(*action);


### PR DESCRIPTION
Summary:

trait Game { fn get_player_score(...) -> f32 }
=>
trait Game {
    type Score: PartialOrd;
    fn get_player_score(...) -> Game::Score
}

TournamentStrategy must also use this generic score.
SwissTournament is only implemented for Score == f32 though (must accumulate each pair's matches results). And since it will only return a TwoPlayerScore (which has nothing to do with matches score, only win/draw/lose), accepting generic scores would not make a result difference.

In addition: since Game and GameFactory traits are only used for this crate (merged previously), I moved the trait bound from Evaluator to trait definition, so that those trait bounds are show earlier to a user implementing its game.