### PR TITLE
Adding CI for build and test

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build and test (Ubuntu, Windows & MacOS)
 
 on:
   push:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -1,0 +1,23 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ai-tournament
 
+![Build and test CI badge](https://github.com/Atsuyo64/ai-tournament/actions/workflows/buildandtest.yml/badge.svg)
+
 A modular Rust crate system for evaluating AI agents via customizable tournaments, supporting sandboxed execution and flexible constraints.
 
 ## Overview


### PR DESCRIPTION
Automated GitHub Actions to execute cargo build and test on Ubuntu, Windows and MacOS :shipit: 